### PR TITLE
Use choices keyword argument to restrict `TYPE` to server or client

### DIFF
--- a/i2plib/tunnel.py
+++ b/i2plib/tunnel.py
@@ -151,7 +151,7 @@ class ServerTunnel(I2PTunnel):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('type', metavar="TYPE", 
+    parser.add_argument('type', metavar="TYPE", choices=('server', 'client'),
                         help="Tunnel type (server or client)")
     parser.add_argument('address', metavar="ADDRESS", 
                         help="Local address (e.g. 127.0.0.1:8000)")


### PR DESCRIPTION
https://github.com/l-n-s/i2plib/blob/d5112ea7393e4dadf18a10fe2c91fda7cf00e303/i2plib/tunnel.py#L179-L186

Currently, a `NameError` would be raised if `args.type` was not entered as either `'server'` or `'client'`.

```python
>>> import argparse
... 
... parser = argparse.ArgumentParser()
... parser.add_argument('type', metavar="TYPE",
...                     help="Tunnel type (server or client)")
... 
... args = parser.parse_args(['NOT_SERVER_OR_CLIENT'])
... 
... if args.type == "client":
...     tunnel = 'client_tunnel'
... elif args.type == "server":
...     tunnel = 'server_tunnel'
... 
... print(tunnel)
... 
Traceback (most recent call last):
  File "<input>", line 14, in <module>
NameError: name 'tunnel' is not defined
```

This could be avoided by adding `choices=('server', 'client')`.

```python
>>> import argparse
... 
... parser = argparse.ArgumentParser()
... parser.add_argument('type', metavar="TYPE", choices=('server', 'client'),
...                     help="Tunnel type (server or client)")
... 
... args = parser.parse_args(['NOT_SERVER_OR_CLIENT'])
... 
... if args.type == "client":
...     tunnel = 'client_tunnel'
... elif args.type == "server":
...     tunnel = 'server_tunnel'
... 
... print(tunnel)
... 
usage: pydevconsole.py [-h] TYPE
pydevconsole.py: error: argument TYPE: invalid choice: 'NOT_SERVER_OR_CLIENT' (choose from 'server', 'client')

```

* https://docs.python.org/3/library/argparse.html#choices
